### PR TITLE
Fix for LoginDialogFragment.dismissAllowingStateLoss() crash

### DIFF
--- a/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
+++ b/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
@@ -148,7 +148,7 @@ public class LoginDialogFragment extends DialogFragment {
         } catch (final IllegalStateException suppressed) {
             // HACK: work around state loss exception if the dialog was added to the back stack
             Timber.tag(TAG)
-                    .d(suppressed, "Error dismissing the LoginDialogFragment, probably because of a Back Stack.");
+                    .e(suppressed, "Error dismissing the LoginDialogFragment, probably because of a Back Stack.");
             getFragmentManager().beginTransaction()
                     .remove(this)
                     .commitAllowingStateLoss();

--- a/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
+++ b/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
@@ -14,6 +14,7 @@ import java.lang.ref.WeakReference;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import me.thekey.android.TheKey;
@@ -32,7 +33,9 @@ public class LoginDialogFragment extends DialogFragment {
     }
 
     // login WebView
-    private FrameLayout frame = null;
+    @Nullable
+    private FrameLayout mFrame = null;
+    @Nullable
     private WebView mLoginView = null;
     @Nullable
     private LoginWebViewClient mLoginWebViewClient = null;
@@ -61,8 +64,8 @@ public class LoginDialogFragment extends DialogFragment {
 
         // build dialog
         final FrameLayout frame =
-                (FrameLayout) LayoutInflater.from(this.getActivity()).inflate(R.layout.thekey_login, null);
-        this.attachLoginView(frame);
+                (FrameLayout) LayoutInflater.from(requireContext()).inflate(R.layout.thekey_login, null);
+        attachLoginView(frame);
         builder.setView(frame);
 
         // handle back button presses to navigate back in the WebView if possible
@@ -93,8 +96,9 @@ public class LoginDialogFragment extends DialogFragment {
 
     /* END lifecycle */
 
-    private void attachLoginView(final FrameLayout frame) {
-        this.detachLoginView();
+    @UiThread
+    private void attachLoginView(@NonNull final FrameLayout frame) {
+        detachLoginView();
 
         // create the LoginWebViewClient if we don't have one yet
         if (mLoginWebViewClient == null) {
@@ -107,9 +111,9 @@ public class LoginDialogFragment extends DialogFragment {
             mLoginView = DisplayUtil.createLoginWebView(frame.getContext(), mLoginWebViewClient, getArguments());
         }
 
-        // attach the login view to the current frame
-        this.frame = frame;
-        this.frame.addView(mLoginView);
+        // attach the login view to the current mFrame
+        mFrame = frame;
+        mFrame.addView(mLoginView);
     }
 
     private void updateLoginWebViewClient() {
@@ -118,17 +122,19 @@ public class LoginDialogFragment extends DialogFragment {
         }
     }
 
+    @UiThread
     private void detachLoginView() {
-        // remove the login view from any existing frame
-        if (this.frame != null) {
+        // remove the login view from any existing mFrame
+        if (mFrame != null) {
             try {
-                this.frame.removeView(mLoginView);
+                mFrame.removeView(mLoginView);
             } catch (final IllegalArgumentException e) {
                 // XXX: KEYAND-12 IllegalArgumentException: Receiver not registered: android.webkit.WebViewClassic
                 Timber.e(e, "error removing Login WebView, let's just reset the login view");
                 mLoginView = null;
+                mLoginWebViewClient = null;
             }
-            this.frame = null;
+            mFrame = null;
         }
     }
 

--- a/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
+++ b/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
@@ -26,6 +26,8 @@ import me.thekey.android.view.util.DisplayUtil;
 import timber.log.Timber;
 
 public class LoginDialogFragment extends DialogFragment {
+    private static final String TAG = "LoginDialogFragment";
+
     public interface Listener {
         void onLoginSuccess(LoginDialogFragment dialog, String guid);
 
@@ -44,7 +46,7 @@ public class LoginDialogFragment extends DialogFragment {
         return new FragmentBuilder<>(LoginDialogFragment.class);
     }
 
-    /* BEGIN lifecycle */
+    // region Lifecycle Events
 
     @Override
     public void onAttach(final Context context) {
@@ -94,7 +96,7 @@ public class LoginDialogFragment extends DialogFragment {
         super.onDestroyView();
     }
 
-    /* END lifecycle */
+    // endregion Lifecycle Events
 
     @UiThread
     private void attachLoginView(@NonNull final FrameLayout frame) {
@@ -130,11 +132,26 @@ public class LoginDialogFragment extends DialogFragment {
                 mFrame.removeView(mLoginView);
             } catch (final IllegalArgumentException e) {
                 // XXX: KEYAND-12 IllegalArgumentException: Receiver not registered: android.webkit.WebViewClassic
-                Timber.e(e, "error removing Login WebView, let's just reset the login view");
+                Timber.tag(TAG)
+                        .e(e, "error removing Login WebView, let's just reset the login view");
                 mLoginView = null;
                 mLoginWebViewClient = null;
             }
             mFrame = null;
+        }
+    }
+
+    @Override
+    public void dismissAllowingStateLoss() {
+        try {
+            super.dismissAllowingStateLoss();
+        } catch (final IllegalStateException suppressed) {
+            // HACK: work around state loss exception if the dialog was added to the back stack
+            Timber.tag(TAG)
+                    .d(suppressed, "Error dismissing the LoginDialogFragment, probably because of a Back Stack.");
+            getFragmentManager().beginTransaction()
+                    .remove(this)
+                    .commitAllowingStateLoss();
         }
     }
 

--- a/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
+++ b/thekey-view-dialog-fragment/src/main/java/me/thekey/android/view/dialog/LoginDialogFragment.java
@@ -113,7 +113,7 @@ public class LoginDialogFragment extends DialogFragment {
             mLoginView = DisplayUtil.createLoginWebView(frame.getContext(), mLoginWebViewClient, getArguments());
         }
 
-        // attach the login view to the current mFrame
+        // attach the login view to the current frame
         mFrame = frame;
         mFrame.addView(mLoginView);
     }
@@ -126,7 +126,7 @@ public class LoginDialogFragment extends DialogFragment {
 
     @UiThread
     private void detachLoginView() {
-        // remove the login view from any existing mFrame
+        // remove the login view from any existing frame
         if (mFrame != null) {
             try {
                 mFrame.removeView(mLoginView);


### PR DESCRIPTION
Fixes: https://console.firebase.google.com/u/0/project/godtools-b2f82/crashlytics/app/android:org.keynote.godtools.android/issues/5b4d273f6007d59fcdc504dc?time=last-ninety-days&sessionId=5BEA7B0E03DE00017DB7314BC550BE4A_DNE_0_v2
