### PR TITLE
Logout can change default session guid

### DIFF
--- a/thekey-core/src/main/java/me/thekey/android/core/PreferenceTheKeyImpl.java
+++ b/thekey-core/src/main/java/me/thekey/android/core/PreferenceTheKeyImpl.java
@@ -2,9 +2,6 @@ package me.thekey.android.core;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RestrictTo;
 import android.text.TextUtils;
 
 import org.json.JSONException;
@@ -19,6 +16,9 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 import me.thekey.android.Attributes;
 
 import static androidx.annotation.RestrictTo.Scope.LIBRARY;
@@ -262,6 +262,9 @@ final class PreferenceTheKeyImpl extends TheKeyImpl {
 
             prefs.apply();
         }
+
+        // reset the default session
+        resetDefaultSession(guid);
 
         if (sendBroadcast) {
             // broadcast a logout action if we had a guid

--- a/thekey-livedata/src/main/java/me/thekey/android/livedata/AttributesLiveData.kt
+++ b/thekey-livedata/src/main/java/me/thekey/android/livedata/AttributesLiveData.kt
@@ -36,7 +36,7 @@ internal class AttributesLiveData(
     }
 
     @AnyThread
-    internal fun invalidateDefaultGuid() {
+    internal fun invalidateForDefaultGuid() {
         if (guid == null) invalidate()
     }
 }

--- a/thekey-livedata/src/main/java/me/thekey/android/livedata/LiveDataRegistry.kt
+++ b/thekey-livedata/src/main/java/me/thekey/android/livedata/LiveDataRegistry.kt
@@ -12,12 +12,20 @@ object LiveDataRegistry : EventsManager {
     internal fun register(liveData: AttributesLiveData) = registry.put(liveData, Unit)
     internal fun register(liveData: DefaultSessionGuidLiveData) = defaultGuidRegistry.put(liveData, Unit)
 
+    override fun changeDefaultSessionEvent(guid: String) {
+        registry.keys.forEach { it.invalidateForDefaultGuid() }
+        defaultGuidRegistry.keys.forEach { it.invalidate() }
+    }
+
     override fun attributesUpdatedEvent(guid: String) {
         registry.keys.forEach { it.invalidateFor(guid) }
     }
 
-    override fun changeDefaultSessionEvent(guid: String) {
-        registry.keys.forEach { it.invalidateDefaultGuid() }
+    override fun logoutEvent(guid: String, changingUser: Boolean) {
+        registry.keys.forEach {
+            it.invalidateFor(guid)
+            it.invalidateForDefaultGuid()
+        }
         defaultGuidRegistry.keys.forEach { it.invalidate() }
     }
 }


### PR DESCRIPTION
Evidently logging out a user didn't initiate reseting the current session guid, which meant that the `defaultSessionGuidLiveData` didn't get updated when a user logged out